### PR TITLE
Log a clearer error message when trying to read a library file that doesn't exist

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -59,8 +59,16 @@ exports.generate = function(files) {
   var failed = false;
   var input = { type: 'Program', body: [] };
   files.forEach(function(file) {
+    var data = null;
     try {
-      var data = fs.readFileSync(file, 'utf8');
+      data = fs.readFileSync(file, 'utf8');
+    } catch (e) {
+      console.error('Could not read file at path ' + file);
+      failed = true;
+      return;
+    }
+
+    try {
       var node = esprima.parse(data, { loc: true });
     } catch (e) {
       var lines = data.split('\n').slice(e.lineNumber - 1, e.lineNumber + 1);


### PR DESCRIPTION
## Test plan

I ran the generator with a file that doesn't exist. Previously, this crashed because the code was as follows...

```
try {
  var data = fs.readFileSync(file, 'utf8');
  var node = esprima.parse(data, { loc: true });
} catch (e) {
   // When `fs.readFileSync(...)` fails above, data is null. Calling split on it crashes the script.
   var lines = data.split('\n').slice(e.lineNumber - 1, e.lineNumber + 1);
   console.error('Could not parse ' + file + ': ' + e.message + '\n\n' + lines.join('\n') + '\n');
   failed = true;
   return;
}
```

After this change, it no longer crashes. It prints out a message like `Could not read file at path /some/path'.